### PR TITLE
don't fail if server includes ip or hostname in header.

### DIFF
--- a/src/main/java/org/graylog/plugins/cef/parser/CEFParser.java
+++ b/src/main/java/org/graylog/plugins/cef/parser/CEFParser.java
@@ -15,7 +15,7 @@ public class CEFParser {
      *   - benchmark regex
      */
 
-    private static final Pattern HEADER_PATTERN = Pattern.compile("^<\\d+>([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}) CEF:(\\d+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)(?:$|(msg=.+))", Pattern.DOTALL);
+    private static final Pattern HEADER_PATTERN = Pattern.compile("^<\\d+>([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2})(?: \\S+)? CEF:(\\d+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)\\|(.+?)(?:$|(msg=.+))", Pattern.DOTALL);
     private static final DateTimeFormatter TIMESTAMP_PATTERN = DateTimeFormat.forPattern("MMM dd HH:mm:ss");
 
     private static final CEFFieldsParser FIELDS_PARSER = new CEFFieldsParser();

--- a/src/test/java/org/graylog/plugins/cef/parser/CEFParserTest.java
+++ b/src/test/java/org/graylog/plugins/cef/parser/CEFParserTest.java
@@ -96,4 +96,16 @@ public class CEFParserTest {
         CEFMessage m = parser.parse("<132>Aug  4 14:26:55 CEF:0|Trend Micro Inc.|OSSEC HIDS|v2.8.3|2502|User missed the password more than one time|10|dvc=ip-172-30-2-212 cfp2=90.01 cfp2Label=SomeFloat spt=22 cs2=ip-172-30-2-212->/var/log/auth.log cs2Label=Location msg=Aug 14 14:26:53 ip-172-30-2-212 sshd[16217]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=116.31.116.17  user=root");
     }
 
+    @Test
+    public void testIpInHeader() throws Exception {
+        CEFParser parser = new CEFParser(DateTimeZone.UTC);
+        CEFMessage m = parser.parse("<14>Feb 17 14:30:54 127.0.0.1 CEF:0|Palo Alto Networks|PAN-OS|7.0.0|vulnerability|THREAT|1|msg=");
+    }
+
+    @Test
+    public void testHostnameInHeader() throws Exception {
+        CEFParser parser = new CEFParser(DateTimeZone.UTC);
+        CEFMessage m = parser.parse("<14>Feb 17 14:30:54 localhost.local CEF:0|Palo Alto Networks|PAN-OS|7.0.0|vulnerability|THREAT|1|msg=");
+    }
+
 }


### PR DESCRIPTION
Tweak regex to allow an optional hostname or IP in header.  Some sources (like a Palo Alto Firewall) don't do native CEF and end up including extra Syslog baggage.  Regex throws away this data anyways but allows   processing to continue.  Also include two new tests for this condition.    For completeness, instructions for reformatting Palo Alto Syslog stream in CEF format are here:

https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/technical-documentation/cef/pan-os-70-CEF-guide.pdf

msg= field from their templates needs to be moved to the end of the line to keep this parser working as expected.